### PR TITLE
add binding for md-html

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 4.0)
 find_package(cmake-bare REQUIRED PATHS node_modules/cmake-bare)
 find_package(cmake-fetch REQUIRED PATHS node_modules/cmake-fetch)
 
-project(bare_md4c CXX C)
+project(bare_md4c C CXX)
 
 fetch_package("github:mity/md4c#481fbfb" SOURCE_DIR MD4C_DIR)
 fetch_package("github:holepunchto/libjstl#34a7894")
@@ -20,6 +20,7 @@ target_link_libraries(
   ${bare_md4c}
   PRIVATE
     $<TARGET_OBJECTS:md4c>
+    $<TARGET_OBJECTS:md4c-html>
     jstl
 )
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,22 @@ npm i bare-md4c
 import md4c from 'bare-md4c'
 ```
 
+### `md4c.toHTML(input, flags, htmlFlags)`
+
+Convert markdown to html
+
+Example:
+
+```js
+const html = md4c.toHTML(mdText)
+```
+
+Parameters:
+
+- `input` - markdown string
+- `flags` - any combination of `md4c.constants.flags`, default: `DIALECT_GITHUB`
+- `htmlFlags` - any combination of `md4c.constants.htmlFlags`, default: none
+
 ### `md4c.parse(input, onparse, flags, logDebug = false)`
 
 Parse text `input`.

--- a/index.js
+++ b/index.js
@@ -6,6 +6,24 @@ exports.parse = function parse(input, onparse, flags = binding.MD_DIALECT_GITHUB
   if (err) throw new Error('parse error')
 }
 
+exports.toHTML = function toHTML(
+  input,
+  parserFlags = binding.MD_DIALECT_GITHUB,
+  htmlFlags = 0
+) {
+  let html = ''
+
+  function onwrite (chunk) {
+    html += chunk
+  }
+
+  const res = binding.toHTML(input, onwrite, parserFlags, htmlFlags)
+
+  if (res < 0) throw new Error('Markdown conversion failed')
+
+  return html
+}
+
 exports.constants = {
   events: {
     BLOCK_ENTER: binding.EV_BLOCK_ENTER,
@@ -87,5 +105,12 @@ exports.constants = {
     LEFT: binding.MD_ALIGN_LEFT,
     CENTER: binding.MD_ALIGN_CENTER,
     RIGHT: binding.MD_ALIGN_RIGHT
+  },
+
+  htmlFlags: {
+    DEBUG: binding.MD_HTML_FLAG_DEBUG,
+    VERBATIM_ENTITIES: binding.MD_HTML_FLAG_VERBATIM_ENTITIES,
+    SKIP_UTF8_BOM: binding.MD_HTML_FLAG_SKIP_UTF8_BOM,
+    XHTML: binding.MD_HTML_FLAG_XHTML
   }
 }

--- a/test.js
+++ b/test.js
@@ -15,3 +15,14 @@ test('parses commonmark spec', (t) => {
     return 0
   }
 })
+
+const htmlFixture = `
+# Hello World
+
+welcome to planet.
+`.trim()
+
+test('generates html', (t) => {
+  const html = md4c.toHTML(htmlFixture)
+  t.is(html, '<h1>Hello World</h1>\n<p>welcome to planet.</p>\n')
+})


### PR DESCRIPTION
Added missing binding to [`md_html()`](https://github.com/mity/md4c/blob/master/src/md4c-html.h#L59)

the bindings to md4c should now be complete.